### PR TITLE
Update web.config for mono

### DIFF
--- a/LogAnalyzer/Web.config
+++ b/LogAnalyzer/Web.config
@@ -39,8 +39,10 @@
   </runtime>
   <system.codedom>
     <compilers>
+      <!--
       <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+      -->
     </compilers>
   </system.codedom>
 </configuration>


### PR DESCRIPTION
To make it work on mono, we need to disable the compiler options.